### PR TITLE
Allow setting a maximum timeout in server middlewares

### DIFF
--- a/ruby/lib/shed.rb
+++ b/ruby/lib/shed.rb
@@ -38,10 +38,19 @@ module Shed
 
     # {with_timeout} sets the timeout deadline for the current context.
     #
+    # By default will only allow setting a new timeout with a deadline that is
+    # _earlier_ than the currently configured deadline. This behaviour can be
+    # overriden by setting `force: true` to extend the deadline.
+    #
     # @param ms [Integer] the timeout in milliseconds.
+    # @param force: [Boolean] whether to force the current timeout.
     # @return [void]
-    def with_timeout(ms)
-      store[KEY] = (now_ms + ms.to_i)
+    def with_timeout(ms, force: false)
+      deadline = (now_ms + ms.to_i)
+
+      return unless earlier?(deadline) || force
+
+      store[KEY] = deadline
     end
 
     # {clear_timeout} will clear any timeout set in the current context.
@@ -91,6 +100,12 @@ module Shed
     end
 
     private
+
+    def earlier?(deadline)
+      return true unless timeout_set?
+
+      deadline < store[KEY]
+    end
 
     def store
       Thread.current

--- a/ruby/lib/shed/rack_middleware.rb
+++ b/ruby/lib/shed/rack_middleware.rb
@@ -1,65 +1,92 @@
 # frozen_string_literal: true
 
 module Shed
-  # {RackMiddleware} implements a rack middleware which uses
-  # {Shed.with_timeout} to propagate client timeouts advertised via
-  # {Shed::HTTP_HEADER} to the request context.
-  class RackMiddleware
-    # {TIMEOUT_APP} implements the default `on_timeout` application, returning
-    # and empty 503 response.
-    TIMEOUT_APP = ->(_) { [503, {}, [""]] }
+  # {RackMiddleware} implements a collection of rack middlewares which can be
+  # used to set and manage {Shed} timeouts and deadlines.
+  module RackMiddleware
+    # {DefaultTimeout} implements a rack middleware which sets a default
+    # timeout on all incoming requests. This sets an upper bound for the
+    # deadline of this request, which may be lowered by other middlewares.
+    class DefaultTimeout
+      # {NO_TIMEOUT} implements the null timeout calculator.
+      NO_TIMEOUT = ->(_) {}
 
-    # {NO_DELTA} implements the default `delta` functions, which always returns
-    # 0, thus not adjusting the request timeout at all.
-    #
-    # @see HerokuDelta
-    NO_DELTA = ->(_) { 0 }
-
-    # @param app The next rack middleware/app in the chain.
-    # @param on_timeout: The rack application to call when a timeout occurs.
-    # @param delta: A callable object which given the current rack environment
-    #   returns a duration in milliseconds to adjust the current timeout by.
-    def initialize(app, on_timeout: TIMEOUT_APP, delta: NO_DELTA)
-      @app = app
-      @on_timeout = on_timeout
-      @delta = delta
-    end
-
-    # {call} processes the current rack request.
-    #
-    # If the current request has a propagated timeout it will be set via
-    # {Shed.with_timeout}.
-    #
-    # If the timeout has already been exceeded (via an adjustment computed by
-    # the `delta` function, the `on_timeout` app will be called immediately.
-    #
-    # Else, the middleware passes control onto the next middleware or application.
-    #
-    # If any downstread middleware or application raises {Shed::Timeout}, this
-    # middleware will rescue this error and call the `on_timeout` app.
-    def call(env)
-      with_timeout(env)
-
-      if Shed.time_left?
-        @app.call(env)
-      else
-        @on_timeout.call(env)
+      # @param app The next rack middleware/app in the chain.
+      # @param max_timeout: A callable object which given the rack environment
+      #   returns the max duration of this request in milliseconds
+      def initialize(app, timeout_ms: NO_TIMEOUT)
+        @app = app
+        @timeout_ms = timeout_ms
       end
-    rescue Shed::Timeout
-      @on_timeout.call(env)
-    ensure
-      Shed.clear_timeout
+
+      def call(env)
+        timeout_ms = @timeout_ms.call(env)
+        Shed.with_timeout(timeout_ms) if timeout_ms
+
+        @app.call(env)
+      end
     end
 
-    private
+    # {Propagate} implements a rack middleware which uses
+    # {Shed.with_timeout} to propagate client timeouts advertised via
+    # {Shed::HTTP_HEADER} to the request context.
+    class Propagate
+      # {TIMEOUT_APP} implements the default `on_timeout` application, returning
+      # and empty 503 response.
+      TIMEOUT_APP = ->(_) { [503, {}, [""]] }
 
-    def with_timeout(env)
-      from_header = env[Shed::RACK_HTTP_HEADER]
-      from_delta = @delta.call(env)
+      # {NO_DELTA} implements the default `delta` functions, which always returns
+      # 0, thus not adjusting the request timeout at all.
+      #
+      # @see HerokuDelta
+      NO_DELTA = ->(_) { 0 }
 
-      return unless from_header
+      # @param app The next rack middleware/app in the chain.
+      # @param on_timeout: The rack application to call when a timeout occurs.
+      # @param delta: A callable object which given the current rack environment
+      #   returns a duration in milliseconds to adjust the current timeout by.
+      def initialize(app, on_timeout: TIMEOUT_APP, delta: NO_DELTA)
+        @app = app
+        @on_timeout = on_timeout
+        @delta = delta
+      end
 
-      Shed.with_timeout(from_header.to_i - from_delta)
+      # {call} processes the current rack request.
+      #
+      # If the current request has a propagated timeout it will be set via
+      # {Shed.with_timeout}.
+      #
+      # If the timeout has already been exceeded (via an adjustment computed by
+      # the `delta` function, the `on_timeout` app will be called immediately.
+      #
+      # Else, the middleware passes control onto the next middleware or application.
+      #
+      # If any downstread middleware or application raises {Shed::Timeout}, this
+      # middleware will rescue this error and call the `on_timeout` app.
+      def call(env)
+        with_timeout(env)
+
+        if Shed.time_left?
+          @app.call(env)
+        else
+          @on_timeout.call(env)
+        end
+      rescue Shed::Timeout
+        @on_timeout.call(env)
+      ensure
+        Shed.clear_timeout
+      end
+
+      private
+
+      def with_timeout(env)
+        from_header = env[Shed::RACK_HTTP_HEADER]
+        from_delta = @delta.call(env)
+
+        return unless from_header
+
+        Shed.with_timeout(from_header.to_i - from_delta)
+      end
     end
   end
 end

--- a/ruby/spec/lib/shed/rack_middleware/default_timeout_spec.rb
+++ b/ruby/spec/lib/shed/rack_middleware/default_timeout_spec.rb
@@ -1,0 +1,46 @@
+# frozen_string_literal: true
+
+require "spec_helper"
+require "rack"
+
+RSpec.describe Shed::RackMiddleware::DefaultTimeout do
+  after { Shed.clear_timeout }
+
+  context "by default" do
+    it "does not set a timeout" do
+      app = ->(env) do
+        expect(Shed.timeout_set?).to eq(false)
+
+        [200, {}, [""]]
+      end
+
+      requestor = Rack::MockRequest.new(described_class.new(app))
+
+      response = requestor.get("/")
+
+      expect(response.status).to eq(200)
+    end
+  end
+
+  context "when timeout_ms returns a non-nil value" do
+    before { allow(Process).to receive(:clock_gettime).and_return(1.0) }
+
+    it "sets a timeout" do
+      timeout_ms = ->(_) { 2_000 }
+      app = ->(env) do
+        expect(Shed.timeout_set?).to eq(true)
+        expect(Shed.time_left_ms).to eq(2_000)
+
+        [200, {}, [""]]
+      end
+
+      requestor = Rack::MockRequest.new(
+        described_class.new(app, timeout_ms: timeout_ms)
+      )
+
+      response = requestor.get("/")
+
+      expect(response.status).to eq(200)
+    end
+  end
+end

--- a/ruby/spec/lib/shed/rack_middleware/propagate_spec.rb
+++ b/ruby/spec/lib/shed/rack_middleware/propagate_spec.rb
@@ -3,7 +3,7 @@
 require "spec_helper"
 require "rack"
 
-RSpec.describe Shed::RackMiddleware do
+RSpec.describe Shed::RackMiddleware::Propagate do
   after { Shed.clear_timeout }
 
   context "when setting X-Client-Timeout-Ms" do


### PR DESCRIPTION
Server timeouts shouldn't be at the whim of any client.
Allow setting an upper-bound to any propagated timeout within server middlewares.