### PR TITLE
Implement shed.WithMaxTimeout option for shed.RoundTrip

### DIFF
--- a/shed_test.go
+++ b/shed_test.go
@@ -20,6 +20,21 @@ func (rt roundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
 	return rt(r)
 }
 
+func response(r *http.Request) *http.Response {
+	resp := "ok\n"
+	return &http.Response{
+		Status:        "200 OK",
+		StatusCode:    200,
+		Proto:         "HTTP/1.1",
+		ProtoMajor:    1,
+		ProtoMinor:    1,
+		Body:          ioutil.NopCloser(bytes.NewBufferString(resp)),
+		ContentLength: int64(len(resp)),
+		Request:       r,
+		Header:        make(http.Header),
+	}
+}
+
 func Test_Client(t *testing.T) {
 	t.Parallel()
 
@@ -28,20 +43,9 @@ func Test_Client(t *testing.T) {
 
 		c := shed.RoundTripper(roundTripper(func(r *http.Request) (*http.Response, error) {
 			assert.NotEmpty(t, r.Header.Get(shed.Header))
-			assert.Equal(t, r.Header.Get(shed.Header), "9999") // this is brittle
+			assert.Contains(t, []string{"10000", "9999"}, r.Header.Get(shed.Header))
 
-			resp := "ok\n"
-			return &http.Response{
-				Status:        "200 OK",
-				StatusCode:    200,
-				Proto:         "HTTP/1.1",
-				ProtoMajor:    1,
-				ProtoMinor:    1,
-				Body:          ioutil.NopCloser(bytes.NewBufferString(resp)),
-				ContentLength: int64(len(resp)),
-				Request:       r,
-				Header:        make(http.Header),
-			}, nil
+			return response(r), nil
 		}))
 
 		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
@@ -61,21 +65,69 @@ func Test_Client(t *testing.T) {
 		c := shed.RoundTripper(roundTripper(func(r *http.Request) (*http.Response, error) {
 			assert.Empty(t, r.Header.Get(shed.Header))
 
-			resp := "ok\n"
-			return &http.Response{
-				Status:        "200 OK",
-				StatusCode:    200,
-				Proto:         "HTTP/1.1",
-				ProtoMajor:    1,
-				ProtoMinor:    1,
-				Body:          ioutil.NopCloser(bytes.NewBufferString(resp)),
-				ContentLength: int64(len(resp)),
-				Request:       r,
-				Header:        make(http.Header),
-			}, nil
+			return response(r), nil
 		}))
 
 		r, err := http.NewRequestWithContext(context.Background(), "GET", "/foo", nil)
+		require.NoError(t, err)
+
+		res, err := c.RoundTrip(r)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("when request context does not have a deadline, with a default", func(t *testing.T) {
+		t.Parallel()
+
+		c := shed.RoundTripper(roundTripper(func(r *http.Request) (*http.Response, error) {
+			assert.Equal(t, "10000", r.Header.Get(shed.Header))
+
+			return response(r), nil
+		}), shed.WithMaxTimeout(10*time.Second))
+
+		r, err := http.NewRequestWithContext(context.Background(), "GET", "/foo", nil)
+		require.NoError(t, err)
+
+		res, err := c.RoundTrip(r)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("when request context has lower deadline than default", func(t *testing.T) {
+		t.Parallel()
+
+		c := shed.RoundTripper(roundTripper(func(r *http.Request) (*http.Response, error) {
+			assert.NotEmpty(t, r.Header.Get(shed.Header))
+			assert.Equal(t, r.Header.Get(shed.Header), "4999") // this is brittle
+
+			return response(r), nil
+		}), shed.WithMaxTimeout(10*time.Second))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+
+		r, err := http.NewRequestWithContext(ctx, "GET", "/foo", nil)
+		require.NoError(t, err)
+
+		res, err := c.RoundTrip(r)
+		require.NoError(t, err)
+		require.NoError(t, res.Body.Close())
+	})
+
+	t.Run("when request context has higher deadline than default", func(t *testing.T) {
+		t.Parallel()
+
+		c := shed.RoundTripper(roundTripper(func(r *http.Request) (*http.Response, error) {
+			assert.NotEmpty(t, r.Header.Get(shed.Header))
+			assert.Contains(t, []string{"10000", "9999"}, r.Header.Get(shed.Header))
+
+			return response(r), nil
+		}), shed.WithMaxTimeout(10*time.Second))
+
+		ctx, cancel := context.WithTimeout(context.Background(), 15*time.Second)
+		defer cancel()
+
+		r, err := http.NewRequestWithContext(ctx, "GET", "/foo", nil)
 		require.NoError(t, err)
 
 		res, err := c.RoundTrip(r)


### PR DESCRIPTION
Enables setting an upper bound on the propagated timeout. Especially
useful in cases where a `context.Context` isn't being used in favour of
something like a ResponseHeaderTimeout.