### PR TITLE
Update README + Shed::FaradayMiddleware

### DIFF
--- a/ruby/README.md
+++ b/ruby/README.md
@@ -1,7 +1,7 @@
 <h1 align="center">🏚 shed</h1>
 
 `shed` implements cross service timeout propagation and load-shedding for your
-`rack` based services and `faraday` based clients.
+Ruby services!
 
 Cross service timeout propagation and load-shedding improve the availability of
 your services under load by reserving resource for requests that are still
@@ -13,8 +13,10 @@ decide, based on the timeout whether the request is worth processing at all
 throughout the lifetime of the request how long is left to process this request
 within the clients declared timeout.
 
-`shed` implements this via a pair of `Rack` and `Faraday` middlewares
-(`Shed::RackMiddleware` and `Shed::FaradayMiddleware`).
+`shed` implements this by integrating with `rack`, `faraday`, `activerecord`,
+`pg`, and `mysql2` gems in order to propgate a shared deadline through service
+calls. This is (somewhat) analogous to deadline propation via the
+`context.Context` package in Go.
 
 For `rails` apps making use of `ActiveRecord` to manage database connections,
 `Shed::ActiveRecord::Adapter` implements support for checking
@@ -22,12 +24,12 @@ For `rails` apps making use of `ActiveRecord` to manage database connections,
 _not_ currently implement support for propagating `Shed.time_left_ms` to the
 database query itself, yet.
 
-## Installing
+## Getting Started
+
+Add `shed` to your Gemfile:
 
 ```ruby
-# Gemfile
-
-# Fetching the latest release
+# for the latest release
 source "https://rubygems.pkg.github.com/cga1123" do
   gem "shed"
 end
@@ -35,3 +37,46 @@ end
 # Fetching the latest HEAD
 gem "shed", github: "CGA1123/shed", glob: "ruby/shed.gemspec"
 ```
+
+Once the gem has been installed, `Shed::RackMiddleware::Propagate` and
+`Shed::RackMiddleware::DefaultTimeout` can be used in order to set the deadline
+either based on a propagated timeout from a client or based on some default
+value. Or both, the lower shortest deadline will win.
+
+For example:
+
+```ruby
+# frozen_string_literal: true
+
+require "shed"
+
+# Set the deadline based on the propagated request header, if set.
+# Adjust the propagated timeout based on the observed queue time (as the
+# difference between the X-Request-Start header and now, as set by Heroku).
+use Shed::RackMiddleware::Propagate, delta: Shed::HerokuDelta
+
+run ->(_env) { [200, {}, ["Hello, world!\n"]] }
+```
+
+If using `rails` the following initializer will set your database queries up to
+respect deadlines, please consult the in-source module documentation for a
+better understanding of how this will impact your queries to the database.
+
+```ruby
+# config/initializers/shed.rb
+ActiveSupport.on_load(:active_record) do
+  Shed::ActiveRecord.setup!
+end
+```
+
+In order to propagate your timeout to other HTTP services use the `faraday`
+middleware:
+
+```ruby
+@connection = Faraday.new(url: "https://example.com") do |conn|
+  conn.request Shed::FaradayMiddleware
+
+  conn.adapter = Faraday.default_adapter
+end
+```
+

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -81,3 +81,10 @@ Shed.register_faraday_middleware!
   conn.adapter Faraday.default_adapter
 end
 ```
+
+This middleware will call `Shed.ensure_time_left!` before checking how long is
+left in the current deadline and setting it as the faraday timeout and
+propagating it via the `X-Client-Timeout-Ms` header.
+
+If the connection already has a timeout set that is _lower_ than the current
+time left in the deadline, it will be used instead.

--- a/ruby/README.md
+++ b/ruby/README.md
@@ -73,10 +73,11 @@ In order to propagate your timeout to other HTTP services use the `faraday`
 middleware:
 
 ```ruby
-@connection = Faraday.new(url: "https://example.com") do |conn|
-  conn.request Shed::FaradayMiddleware
+Shed.register_faraday_middleware!
 
-  conn.adapter = Faraday.default_adapter
+@connection = Faraday.new(url: "https://example.com") do |conn|
+  conn.request :shed
+
+  conn.adapter Faraday.default_adapter
 end
 ```
-

--- a/ruby/lib/shed.rb
+++ b/ruby/lib/shed.rb
@@ -29,6 +29,14 @@ module Shed
   private_constant :KEY
 
   class << self
+    # {register_faraday_middleware!} registers {Shed::FaradayMiddleware} on
+    # `Faraday::Request`, allowing it to be used in faraday connections.
+    def register_faraday_middleware!
+      Faraday::Request.register_middleware(
+        shed: Shed::FaradayMiddleware
+      )
+    end
+
     # {timeout_set?} returns whether there is a timeout set in the current
     # context.
     #


### PR DESCRIPTION
- Update the `ruby/README.md` with more details on how to get started
- Update `Shed::FaradayMiddleware` to use `on_request` hook and check time left before request.